### PR TITLE
chore(ci): Add nodejs 20 and remove support for 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [18, 20]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Closes #23 

Node.js 16 is currently officially unsupported; we should remove it and add support for Node.js 20 instead in the CI build matrix.