### PR TITLE
chore: release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.2.15
+
+[compare changes](https://github.com/stackbuilders/nuxt-utm/compare/v0.2.14...v0.2.15)
+
+### 🏡 Chore
+
+- **deps-dev:** Bump nuxt from 4.4.4 to 4.4.6 ([#124](https://github.com/stackbuilders/nuxt-utm/pull/124))
+- **deps-dev:** Bump nuxt from 4.4.4 to 4.4.6 in /playground ([#125](https://github.com/stackbuilders/nuxt-utm/pull/125))
+
 ## v0.2.14
 
 [compare changes](https://github.com/stackbuilders/nuxt-utm/compare/v0.2.13...v0.2.14)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-utm",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "A Nuxt 3/4 module for tracking UTM parameters.",
   "keywords": [
     "nuxt",


### PR DESCRIPTION
## Summary
- bump nuxt-utm from 0.2.14 to 0.2.15
- update CHANGELOG.md for v0.2.15

## Validation
- npm run lint -- --max-warnings 0
- npm test (rerun outside sandbox for local 127.0.0.1 integration ports)
- npm run dev:build
- npm --cache /private/tmp/nuxt-utm-npm-cache pack --dry-run

Note: npm publish should run via the repository release workflow after this PR is merged.