### PR TITLE
chore: automate safe Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,20 @@
 version: 2
 
 updates:
-  # Keep the repository's existing security-update-only policy while applying
-  # consistent ownership to both Yarn lockfiles.
+  # Wait for routine releases to stabilize before Dependabot proposes them.
+  # GitHub intentionally bypasses cooldowns for known vulnerability fixes.
   - package-ecosystem: npm
     directories:
       - '/'
       - '/playground'
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
+    open-pull-requests-limit: 5
     assignees:
       - sadjow
     reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  # Keep the repository's existing security-update-only policy while applying
+  # consistent ownership to both Yarn lockfiles.
+  - package-ecosystem: npm
+    directories:
+      - '/'
+      - '/playground'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    assignees:
+      - sadjow
+    reviewers:
+      - sadjow

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -4,6 +4,7 @@ repository:
   has_projects: false
   has_wiki: true
   default_branch: main
+  allow_auto_merge: true
   allow_squash_merge: true
   allow_merge_commit: false
   allow_rebase_merge: false
@@ -12,6 +13,12 @@ repository:
 branches:
   - name: main
     protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - 'build (20)'
+          - 'build (22)'
+
       required_pull_request_reviews:
         required_approving_review_count: 1
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'stackbuilders/nuxt-utm'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Approve patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          PR_URL: '${{ github.event.pull_request.html_url }}'
+
+      - name: Enable squash auto-merge for patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          PR_URL: '${{ github.event.pull_request.html_url }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,13 @@
 name: CI
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -10,21 +17,22 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [20, 22]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
@@ -40,7 +48,7 @@ jobs:
         run: yarn list
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - run: yarn lint --max-warnings 0
 
@@ -49,3 +57,11 @@ jobs:
 
       - name: Execute tests
         run: yarn test
+
+      - name: Install playground dependencies
+        working-directory: playground
+        run: yarn install --frozen-lockfile
+
+      - name: Build playground from its lockfile
+        working-directory: playground
+        run: yarn build


### PR DESCRIPTION
## Summary

- require frozen installs for both the root and playground Yarn lockfiles
- run CI for pull requests and require both Node 20 and Node 22 matrix checks
- assign and request review from `sadjow` on Dependabot updates
- enable routine npm/Yarn version updates with at most five open PRs
- apply release-age cooldowns: 7 days for patches/default, 14 for minors, and 30 for majors
- auto-approve and enable squash auto-merge only for patch and minor Dependabot updates
- leave major updates and failed CI for manual review
- let security updates bypass cooldown, as GitHub requires, while retaining CI gates
- persist repository auto-merge and strict branch-protection settings

## Validation

- `actionlint` on both changed workflows
- Prettier and YAML parsing on all changed configuration
- explicit validation of cooldown fields and GitHub-supported 1–90 day ranges
- frozen root and playground installs
- lint, root build, playground build, and 22 unit tests on Node 22
- lint, build paths, and 22 unit tests on Node 20

The full integration suite runs in the required GitHub Actions matrix.