### PR TITLE
chore: test maintained Node.js releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24, 26]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn dev:build

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 22.15.1
+nodejs 24.19.0
 yarn 1.22.19


### PR DESCRIPTION
## Summary

- test the latest patch releases of Node.js 22, 24, and 26 in CI
- use the latest Node.js 24 release for local development
- use Node.js 24 for npm publishing workflows
- keep the package free of an `engines` restriction so other Node.js versions can still be tried on a best-effort basis

The CI matrix defines the major versions the project actively verifies; it does not block installation on other versions.

## Validation

- root and playground frozen-lockfile installs
- `yarn lint --max-warnings 0`
- all 53 tests on Node.js 22.22, 24.13, and 26.7
- Nuxt production builds on Node.js 22.22, 24.13, and 26.7
- standalone playground build
- `npm pack --dry-run` on Node.js 24.13

## Existing issue

`yarn test:types` continues to report existing strict-nullability errors in runtime and test files. This PR does not change TypeScript sources, and the command is not part of the current CI workflow.