### PR TITLE
chore: harden Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot auto-merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Read Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 


### PR DESCRIPTION
## Summary

- run privileged Dependabot metadata automation from the trusted default-branch workflow with `pull_request_target`
- update the pinned `dependabot/fetch-metadata` action from v2.3.0 to v3.1.0
- retain the Dependabot author and repository guards

## Context

The review of #148 raised a concern about write permissions on Dependabot-triggered workflows. The existing workflow has operated successfully because this repository allows workflows to request write permissions: its logs show both approval and auto-merge succeeding for eligible updates.

This follow-up adopts the safer trusted-base event recommended for metadata-only automation. The workflow does not check out, download, or execute pull request code. It also moves the metadata action to its Node 24 runtime and removes the current Node 20 deprecation warning.

The repository guard remains intentional so a fork or copied workflow does not inherit privileged auto-merge behavior.

## Validation

- `actionlint .github/workflows/dependabot-auto-merge.yml`
- Prettier check for the changed workflow
- verified that the pinned SHA is the signed v3.1.0 commit
- verified that v3.1.0 declares the Node 24 Actions runtime

## References

- [Securely using `pull_request_target`](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)
- [`dependabot/fetch-metadata` v3.1.0](https://github.com/dependabot/fetch-metadata/releases/tag/v3.1.0)